### PR TITLE
let StochasticProcess subclasses define "apply" method

### DIFF
--- a/pyesg/processes/academy_rate_process.py
+++ b/pyesg/processes/academy_rate_process.py
@@ -138,7 +138,9 @@ class AcademyRateProcess(JointStochasticProcess):
         )
 
     def apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
-        # arithmetic addition to update x0
+        # long-rate (x0[0]) is modeled internally as a log process, so we use exp
+        # spread (x0[1]) is an arithmetic process
+        # volatility (x0[2]) is modeled internally as a log-process, so we use exp
         out = x0.copy()
         out[0] = x0[0] * np.exp(dx[0])
         out[1] = x0[1] + dx[1]

--- a/pyesg/processes/academy_rate_process.py
+++ b/pyesg/processes/academy_rate_process.py
@@ -15,9 +15,9 @@ class AcademyRateProcess(JointStochasticProcess):
     """
     American Academy of Actuaries stochastic log volatility process. Models three linked
     processes:
-        1 : log-long-term-rate
+        1 : long-term-rate (internally modeled as a process on the log-rate)
         2 : nominal spread between long-term rate and short-term rate
-        3 : log-monthly-volatility of the log-long-rate process
+        3 : monthly-volatility of the long-rate process (internally modeled as log-vol)
 
     NOTE : most parameters provided as defaults are _monthly_ parameters, not _annual_
         parameters; to keep consistent with the Academy Excel workbook, these values are
@@ -52,20 +52,20 @@ class AcademyRateProcess(JointStochasticProcess):
     array([[ 1.     , -0.19197,  0.     ],
            [-0.19197,  1.     ,  0.     ],
            [ 0.     ,  0.     ,  1.     ]])
-    >>> arp.drift(x0=[np.log(0.0287), 0.0024, 0.03])
+    >>> arp.drift(x0=[0.0287, 0.0024, 0.03])
     array([ 0.03507095,  0.00197244, -0.02126944])
-    >>> arp.diffusion(x0=[np.log(0.0287), 0.0024, 0.03])
+    >>> arp.diffusion(x0=[0.0287, 0.0024, 0.03])
     array([[ 0.10392305,  0.        ,  0.        ],
            [-0.00079167,  0.00404723,  0.        ],
            [ 0.        ,  0.        ,  0.39799063]])
-    >>> arp.expectation(x0=[np.log(0.0287), 0.0024, 0.03], dt=1./12)
-    array([-3.54793558e+00,  2.56436981e-03,  2.99468735e-02])
-    >>> arp.standard_deviation(x0=[np.log(0.0287), 0.0024, 0.03], dt=1./12)
+    >>> arp.expectation(x0=[0.0287, 0.0024, 0.03], dt=1./12)
+    array([0.028784  , 0.00256437, 0.02994687])
+    >>> arp.standard_deviation(x0=[0.0287, 0.0024, 0.03], dt=1./12)
     array([[ 0.03      ,  0.        ,  0.        ],
            [-0.00022854,  0.00116833,  0.        ],
            [ 0.        ,  0.        ,  0.11489   ]])
-    >>> arp.step(x0=[np.log(0.0287), 0.0024, 0.03], dt=1./12, random_state=42)
-    array([-3.53303415e+00,  2.28931401e-03,  3.22603159e-02])
+    >>> arp.step(x0=[0.0287, 0.0024, 0.03], dt=1./12, random_state=42)
+    array([0.02921614, 0.00228931, 0.03226032])
     """
 
     # pylint: disable=too-many-arguments,too-many-instance-attributes,too-many-locals
@@ -140,13 +140,13 @@ class AcademyRateProcess(JointStochasticProcess):
     def apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
         # arithmetic addition to update x0
         out = x0.copy()
-        out[0] = x0[0] + dx[0]
+        out[0] = x0[0] * np.exp(dx[0])
         out[1] = x0[1] + dx[1]
         out[2] = x0[2] * np.exp(dx[2])
         return out
 
     def _drift(self, x0: np.ndarray) -> np.ndarray:
-        # x0 is an array of [log-long-rate, nominal spread, volatility]
+        # x0 is an array of [long-rate, nominal spread, volatility]
         # create a new array to store the output, then simultaneously update all terms
         out = x0.copy()
 
@@ -154,26 +154,22 @@ class AcademyRateProcess(JointStochasticProcess):
         out[2] = self.beta3 * np.log(self.tau3 / x0[2])
 
         # updating spread
-        out[1] = self.beta2 * (self.tau2 - x0[1]) + self.phi * (
-            x0[0] - np.log(self.tau1)
-        )
+        out[1] = self.beta2 * (self.tau2 - x0[1]) + self.phi * np.log(x0[0] / self.tau1)
 
         # expectation for the log-long-term rate
-        out[0] = self.beta1 * (np.log(self.tau1) - x0[0]) + self.psi * (
-            self.tau2 - x0[1]
-        )
-        out[0] = min(np.log(self.long_rate_max) - x0[0], out[0])
-        out[0] = max(np.log(self.long_rate_min) - x0[0], out[0])
+        out[0] = self.beta1 * np.log(self.tau1 / x0[0]) + self.psi * (self.tau2 - x0[1])
+        out[0] = min(self.long_rate_max - x0[0], out[0])
+        out[0] = max(self.long_rate_min - x0[0], out[0])
         return out
 
     def _diffusion(self, x0: np.ndarray) -> np.ndarray:
         # diffusion is the covariance diagonal times the cholesky correlation matrix
-        # x0 is an array of [log-long-rate, spread, volatility]
+        # x0 is an array of [long-rate, spread, volatility]
         cholesky = np.linalg.cholesky(self.correlation)
         volatility = np.diag(
             [
                 x0[2] * 12 ** 0.5,  # annualize the monthly-based parameter
-                self.sigma2 * np.exp(x0[0]) ** self.theta,
+                self.sigma2 * x0[0] ** self.theta,
                 self.sigma3,
             ]
         )

--- a/pyesg/processes/academy_rate_process.py
+++ b/pyesg/processes/academy_rate_process.py
@@ -52,20 +52,20 @@ class AcademyRateProcess(JointStochasticProcess):
     array([[ 1.     , -0.19197,  0.     ],
            [-0.19197,  1.     ,  0.     ],
            [ 0.     ,  0.     ,  1.     ]])
-    >>> arp.drift(x0=[np.log(0.0287), 0.0024, np.log(0.0287)])
-    array([0.03507095, 0.00197244, 0.        ])
-    >>> arp.diffusion(x0=[np.log(0.0287), 0.0024, np.log(0.0287)])
-    array([[ 0.09941972,  0.        ,  0.        ],
+    >>> arp.drift(x0=[np.log(0.0287), 0.0024, np.log(0.03)])
+    array([ 0.03507095,  0.00197244, -0.02126944])
+    >>> arp.diffusion(x0=[np.log(0.0287), 0.0024, np.log(0.03)])
+    array([[ 0.10392305,  0.        ,  0.        ],
            [-0.00079167,  0.00404723,  0.        ],
            [ 0.        ,  0.        ,  0.39799063]])
-    >>> arp.expectation(x0=[np.log(0.0287), 0.0024, np.log(0.0287)], dt=1./12)
-    array([-3.54793558e+00,  2.56436981e-03, -3.55085816e+00])
-    >>> arp.standard_deviation(x0=[np.log(0.0287), 0.0024, np.log(0.0287)], dt=1./12)
-    array([[ 0.0287    ,  0.        ,  0.        ],
+    >>> arp.expectation(x0=[np.log(0.0287), 0.0024, np.log(0.03)], dt=1./12)
+    array([-3.54793558e+00,  2.56436981e-03, -3.50833035e+00])
+    >>> arp.standard_deviation(x0=[np.log(0.0287), 0.0024, np.log(0.03)], dt=1./12)
+    array([[ 0.03      ,  0.        ,  0.        ],
            [-0.00022854,  0.00116833,  0.        ],
            [ 0.        ,  0.        ,  0.11489   ]])
-    >>> arp.step(x0=[np.log(0.0287), 0.0024, np.log(0.0287)], dt=1./12, random_state=42)
-    array([-3.53367988e+00,  2.28931401e-03, -3.47644522e+00])
+    >>> arp.step(x0=[np.log(0.0287), 0.0024, np.log(0.03)], dt=1./12, random_state=42)
+    array([-3.53303415e+00,  2.28931401e-03, -3.43391741e+00])
     """
 
     # pylint: disable=too-many-arguments,too-many-instance-attributes,too-many-locals

--- a/pyesg/processes/academy_rate_process.py
+++ b/pyesg/processes/academy_rate_process.py
@@ -139,7 +139,11 @@ class AcademyRateProcess(JointStochasticProcess):
 
     def apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
         # arithmetic addition to update x0
-        return x0 + dx
+        out = x0.copy()
+        out[0] = x0[0] + dx[0]
+        out[1] = x0[1] + dx[1]
+        out[2] = x0[2] + dx[2]
+        return out
 
     def _drift(self, x0: np.ndarray) -> np.ndarray:
         # x0 is an array of [log-long-rate, nominal spread, log-volatility]
@@ -159,7 +163,7 @@ class AcademyRateProcess(JointStochasticProcess):
             self.tau2 - x0[1]
         )
         out[0] = min(np.log(self.long_rate_max) - x0[0], out[0])
-        x0[0] = max(np.log(self.long_rate_min) - x0[0], out[0])
+        out[0] = max(np.log(self.long_rate_min) - x0[0], out[0])
         return out
 
     def _diffusion(self, x0: np.ndarray) -> np.ndarray:

--- a/pyesg/processes/academy_rate_process.py
+++ b/pyesg/processes/academy_rate_process.py
@@ -137,6 +137,10 @@ class AcademyRateProcess(JointStochasticProcess):
             long_rate_min=self.long_rate_min,
         )
 
+    def apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
+        # arithmetic addition to update x0
+        return x0 + dx
+
     def _drift(self, x0: np.ndarray) -> np.ndarray:
         # x0 is an array of [log-long-rate, nominal spread, log-volatility]
         # create a new array to store the output, then simultaneously update all terms

--- a/pyesg/processes/cox_ingersoll_ross_process.py
+++ b/pyesg/processes/cox_ingersoll_ross_process.py
@@ -37,6 +37,10 @@ class CoxIngersollRossProcess(StochasticProcess):
     def coefs(self) -> Dict[str, float]:
         return dict(mu=self.mu, sigma=self.sigma, theta=self.theta)
 
+    def apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
+        # arithmetic addition to update x0
+        return x0 + dx
+
     def _drift(self, x0: np.ndarray) -> np.ndarray:
         return self.theta * (self.mu - x0)
 

--- a/pyesg/processes/geometric_brownian_motion.py
+++ b/pyesg/processes/geometric_brownian_motion.py
@@ -38,6 +38,10 @@ class GeometricBrownianMotion(StochasticProcess):
     def coefs(self) -> Dict[str, float]:
         return dict(mu=self.mu, sigma=self.sigma)
 
+    def apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
+        # arithmetic addition to update x0
+        return x0 + dx
+
     def _drift(self, x0: np.ndarray) -> np.ndarray:
         return self.mu * x0
 

--- a/pyesg/processes/heston_process.py
+++ b/pyesg/processes/heston_process.py
@@ -51,6 +51,10 @@ class HestonProcess(JointStochasticProcess):
             rho=self.rho,
         )
 
+    def apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
+        # arithmetic addition to update x0
+        return x0 + dx
+
     def _drift(self, x0: np.ndarray) -> np.ndarray:
         # floor volatility at zero before continuing (truncation method)
         vol = max(0.0, x0[1] ** 0.5)

--- a/pyesg/processes/ornstein_uhlenbeck_process.py
+++ b/pyesg/processes/ornstein_uhlenbeck_process.py
@@ -36,6 +36,10 @@ class OrnsteinUhlenbeckProcess(StochasticProcess):
     def coefs(self) -> Dict[str, float]:
         return dict(mu=self.mu, sigma=self.sigma, theta=self.theta)
 
+    def apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
+        # arithmetic addition to update x0
+        return x0 + dx
+
     def _drift(self, x0: np.ndarray) -> np.ndarray:
         return self.theta * (self.mu - x0)
 

--- a/pyesg/processes/wiener_process.py
+++ b/pyesg/processes/wiener_process.py
@@ -37,6 +37,10 @@ class WienerProcess(StochasticProcess):
     def coefs(self) -> Dict[str, float]:
         return dict(mu=self.mu, sigma=self.sigma)
 
+    def apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
+        # arithmetic addition to update x0
+        return x0 + dx
+
     def _drift(self, x0: np.ndarray) -> np.ndarray:
         # drift of a Wiener process does not depend on x0
         return to_array(self.mu)
@@ -85,6 +89,10 @@ class JointWienerProcess(JointStochasticProcess):
 
     def coefs(self) -> Dict[str, np.ndarray]:
         return dict(mu=self.mu, sigma=self.sigma, correlation=self.correlation)
+
+    def apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
+        # arithmetic addition to update x0
+        return x0 + dx
 
     def _drift(self, x0: np.ndarray) -> np.ndarray:
         # mu is already an array of expected returns; it doesn't depend on x0

--- a/pyesg/stochastic_process.py
+++ b/pyesg/stochastic_process.py
@@ -37,6 +37,10 @@ class StochasticProcess(ABC):
         """Returns the diffusion component of the stochastic process"""
 
     @abstractmethod
+    def apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
+        """Returns a new array of x-values, given a starting array and change vector"""
+
+    @abstractmethod
     def coefs(self) -> Dict[str, np.ndarray]:
         """Returns a dictionary of the process coefficients"""
 
@@ -53,7 +57,7 @@ class StochasticProcess(ABC):
         Returns the expected value of the stochastic process using the Euler
         Discretization method
         """
-        return to_array(x0) + self.drift(x0=x0) * dt
+        return self.apply(to_array(x0), self.drift(x0=x0) * dt)
 
     def standard_deviation(self, x0: Array, dt: float) -> np.ndarray:
         """
@@ -94,8 +98,8 @@ class StochasticProcess(ABC):
         """
         x0 = to_array(x0)
         rvs = self.dW.rvs(size=x0.shape, random_state=check_random_state(random_state))
-        return to_array(
-            self.expectation(x0=x0, dt=dt) + rvs * self.standard_deviation(x0=x0, dt=dt)
+        return self.apply(
+            self.expectation(x0=x0, dt=dt), rvs * self.standard_deviation(x0=x0, dt=dt)
         )
 
 

--- a/pyesg/stochastic_process.py
+++ b/pyesg/stochastic_process.py
@@ -131,7 +131,7 @@ class JointStochasticProcess(StochasticProcess):  # pylint: disable=abstract-met
         rvs = self.dW.rvs(
             size=x0[None, :].shape, random_state=check_random_state(random_state)
         )
-        return (
-            self.expectation(x0=x0, dt=dt)
-            + (rvs @ self.standard_deviation(x0=x0, dt=dt).T).squeeze()
+        return self.apply(
+            self.expectation(x0=x0, dt=dt),
+            (rvs @ self.standard_deviation(x0=x0, dt=dt).T).squeeze(),
         )


### PR DESCRIPTION
Previously, `StochasticProcess` assumed drift and diffusion were added by default. This change requires subclasses to specify the method to apply changes, e.g. by addition or multiplication. This will allow easier handling of multiplicative relationships, e.g. log-transforms for certain processes.