### PR TITLE
Consolidate JointStochasticProcess into StochasticProcess

### DIFF
--- a/pyesg/processes/academy_rate_process.py
+++ b/pyesg/processes/academy_rate_process.py
@@ -8,10 +8,10 @@ https://www.actuary.org/sites/default/files/pdf/life/lbrc_dec08.pdf, page 8
 from typing import Dict
 import numpy as np
 
-from pyesg.stochastic_process import JointStochasticProcess
+from pyesg.stochastic_process import StochasticProcess
 
 
-class AcademyRateProcess(JointStochasticProcess):
+class AcademyRateProcess(StochasticProcess):
     """
     American Academy of Actuaries stochastic log volatility process. Models three linked
     processes:
@@ -92,7 +92,7 @@ class AcademyRateProcess(JointStochasticProcess):
         long_rate_max: float = 0.18,  # soft cap of the long rate before perturbing
         long_rate_min: float = 0.0115,  # soft floor of the long rate before perturbing
     ) -> None:
-        super().__init__()
+        super().__init__(dim=3)
         self.beta1 = beta1 * 12  # annualize the monthly-based parameter
         self.beta2 = beta2 * 12  # annualize the monthly-based parameter
         self.beta3 = beta3 * 12  # annualize the monthly-based parameter

--- a/pyesg/processes/academy_rate_process.py
+++ b/pyesg/processes/academy_rate_process.py
@@ -141,7 +141,7 @@ class AcademyRateProcess(JointStochasticProcess):
             long_rate_min=self.long_rate_min,
         )
 
-    def apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
+    def _apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
         # long-rate (x0[0]) is modeled internally as a log process, so we use exp
         # spread (x0[1]) is an arithmetic process
         # volatility (x0[2]) is modeled internally as a log-process, so we use exp

--- a/pyesg/processes/cox_ingersoll_ross_process.py
+++ b/pyesg/processes/cox_ingersoll_ross_process.py
@@ -22,8 +22,8 @@ class CoxIngersollRossProcess(StochasticProcess):
     array([0.00244949])
     >>> cir.step(x0=0.03, dt=1.0, random_state=42)
     array([0.03372067])
-    >>> cir.step(x0=[0.03, 0.05, 0.09], dt=1.0, random_state=42)
-    array([0.03372067, 0.04938166, 0.08988613])
+    >>> cir.step(x0=[0.03], dt=1.0, random_state=42)
+    array([0.03372067])
     >>> cir.logpdf(x0=0.05, xt=0.02, dt=1.0)
     array([-18.00904939])
     """
@@ -37,7 +37,7 @@ class CoxIngersollRossProcess(StochasticProcess):
     def coefs(self) -> Dict[str, float]:
         return dict(mu=self.mu, sigma=self.sigma, theta=self.theta)
 
-    def apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
+    def _apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
         # arithmetic addition to update x0
         return x0 + dx
 

--- a/pyesg/processes/geometric_brownian_motion.py
+++ b/pyesg/processes/geometric_brownian_motion.py
@@ -24,8 +24,8 @@ class GeometricBrownianMotion(StochasticProcess):
     array([0.14142136])
     >>> gbm.step(x0=1.0, dt=1.0, random_state=42)
     array([1.14934283])
-    >>> gbm.step(x0=[1.0, 15.0, 50.0], dt=1.0, random_state=42)
-    array([ 1.14934283, 15.3352071 , 58.97688538])
+    >>> gbm.step(x0=[1.0], dt=1.0, random_state=42)
+    array([1.14934283])
     >>> gbm.logpdf(x0=1.0, xt=1.1, dt=1.0)
     array([0.65924938])
     """
@@ -38,7 +38,7 @@ class GeometricBrownianMotion(StochasticProcess):
     def coefs(self) -> Dict[str, float]:
         return dict(mu=self.mu, sigma=self.sigma)
 
-    def apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
+    def _apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
         # arithmetic addition to update x0
         return x0 + dx
 

--- a/pyesg/processes/heston_process.py
+++ b/pyesg/processes/heston_process.py
@@ -2,10 +2,10 @@
 from typing import Dict
 import numpy as np
 
-from pyesg.stochastic_process import JointStochasticProcess
+from pyesg.stochastic_process import StochasticProcess
 
 
-class HestonProcess(JointStochasticProcess):
+class HestonProcess(StochasticProcess):
     """
     Heston stochastic volatility process
 
@@ -30,7 +30,7 @@ class HestonProcess(JointStochasticProcess):
     def __init__(
         self, mu: float, theta: float, kappa: float, sigma: float, rho: float
     ) -> None:
-        super().__init__()
+        super().__init__(dim=2)
         self.mu = mu
         self.theta = theta
         self.kappa = kappa

--- a/pyesg/processes/heston_process.py
+++ b/pyesg/processes/heston_process.py
@@ -51,7 +51,7 @@ class HestonProcess(JointStochasticProcess):
             rho=self.rho,
         )
 
-    def apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
+    def _apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
         # arithmetic addition to update x0
         return x0 + dx
 

--- a/pyesg/processes/ornstein_uhlenbeck_process.py
+++ b/pyesg/processes/ornstein_uhlenbeck_process.py
@@ -36,7 +36,7 @@ class OrnsteinUhlenbeckProcess(StochasticProcess):
     def coefs(self) -> Dict[str, float]:
         return dict(mu=self.mu, sigma=self.sigma, theta=self.theta)
 
-    def apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
+    def _apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
         # arithmetic addition to update x0
         return x0 + dx
 

--- a/pyesg/processes/wiener_process.py
+++ b/pyesg/processes/wiener_process.py
@@ -25,8 +25,8 @@ class WienerProcess(StochasticProcess):
     array([0.14142136])
     >>> wp.step(x0=0.0, dt=1.0, random_state=42)
     array([0.14934283])
-    >>> wp.step(x0=np.array([0.0, 1.0, 2.0]), dt=1.0, random_state=42)
-    array([0.14934283, 1.02234714, 2.17953771])
+    >>> wp.step(x0=np.array([1.0]), dt=1.0, random_state=42)
+    array([1.14934283])
     """
 
     def __init__(self, mu: float, sigma: float) -> None:
@@ -37,7 +37,7 @@ class WienerProcess(StochasticProcess):
     def coefs(self) -> Dict[str, float]:
         return dict(mu=self.mu, sigma=self.sigma)
 
-    def apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
+    def _apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
         # arithmetic addition to update x0
         return x0 + dx
 
@@ -90,7 +90,7 @@ class JointWienerProcess(JointStochasticProcess):
     def coefs(self) -> Dict[str, np.ndarray]:
         return dict(mu=self.mu, sigma=self.sigma, correlation=self.correlation)
 
-    def apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
+    def _apply(self, x0: np.ndarray, dx: np.ndarray) -> np.ndarray:
         # arithmetic addition to update x0
         return x0 + dx
 

--- a/pyesg/processes/wiener_process.py
+++ b/pyesg/processes/wiener_process.py
@@ -2,7 +2,7 @@
 from typing import Dict, List, Union
 import numpy as np
 
-from pyesg.stochastic_process import JointStochasticProcess, StochasticProcess
+from pyesg.stochastic_process import StochasticProcess
 from pyesg.utils import to_array
 
 
@@ -50,7 +50,7 @@ class WienerProcess(StochasticProcess):
         return to_array(self.sigma)
 
 
-class JointWienerProcess(JointStochasticProcess):
+class JointWienerProcess(StochasticProcess):
     """
     Joint Wiener processes: dX = μdt + σdW
 
@@ -82,7 +82,7 @@ class JointWienerProcess(JointStochasticProcess):
         sigma: Union[List[float], List[int], np.ndarray],
         correlation: Union[List[float], np.ndarray],
     ) -> None:
-        super().__init__()
+        super().__init__(dim=len(mu))
         self.mu = to_array(mu)
         self.sigma = to_array(sigma)
         self.correlation = to_array(correlation)

--- a/pyesg/stochastic_process.py
+++ b/pyesg/stochastic_process.py
@@ -118,43 +118,16 @@ class StochasticProcess(ABC):
         Discretization method
         """
         x0 = to_array(x0)
+
+        # generate an array of independent draws from the dW distribution (defaults to a
+        # normal distribution.) In the general case, we can use matrix multiplication to
+        # combine the random draws with the StochasticProcess's standard deviation. This
+        # means that we can handle both single-dimensional and multi-dimensional
+        # stochastic processes with a single abstract base class. For joint stochastic
+        # processes, the standard deviation is a n x n matrix, where n is the dimension
+        # of the process, so we effectively convert the independent random draws into
+        # correlated random draws.
         rvs = self.dW.rvs(size=x0.shape, random_state=check_random_state(random_state))
-        return self.apply(
-            self.expectation(x0=x0, dt=dt),
-            (rvs @ self.standard_deviation(x0=x0, dt=dt).T).squeeze(),
-        )
-
-
-class JointStochasticProcess(StochasticProcess):  # pylint: disable=abstract-method
-    """
-    Abstract base class for a joint stochastic diffusion process: a process that
-    comprises at least two correlated stochastic processes whose values may or may not
-    depend on one another. This base class inherits most of its functionality from the
-    StochasticProcess abstract class, and only slightly modifies the "step" method to
-    handle correlation between the processes.
-
-    Parameters
-    ----------
-    correlation : np.ndarray, a square matrix of correlations among the stochastic
-        portions of the processes. Its shape must match the number of processes
-    dW : Scipy stats distribution object, default scipy.stats.norm. Specifies the
-        distribution from which samples should be drawn.
-    """
-
-    def __init__(self, dW: rv_continuous = stats.norm) -> None:
-        super().__init__(dW=dW)
-
-    def step(
-        self, x0: Array, dt: float, random_state: RandomState = None
-    ) -> np.ndarray:
-        """
-        Applies the stochastic process to an array of initial values using the Euler
-        Discretization method
-        """
-        x0 = to_array(x0)
-        rvs = self.dW.rvs(
-            size=x0[None, :].shape, random_state=check_random_state(random_state)
-        )
         return self.apply(
             self.expectation(x0=x0, dt=dt),
             (rvs @ self.standard_deviation(x0=x0, dt=dt).T).squeeze(),

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -50,8 +50,6 @@ class TestWienerProcess(unittest.TestCase):
         self.assertEqual(steps.shape, (1,))
         steps = model.step(x0=np.array([0.05]), dt=1.0, random_state=None)
         self.assertEqual(steps.shape, (1,))
-        steps = model.step(x0=np.full(10, 0.05), dt=1.0, random_state=None)
-        self.assertEqual(steps.shape, (10,))
 
 
 class TestAcademyRateProcess(unittest.TestCase):


### PR DESCRIPTION
I've felt for a while that `JointStochasticProcess` was an unnecessary extension of the `StochasticProcess` abstract base class. All it did was explicitly use matrix multiplication for the `step` method, rather than multiplication, as is the case for the base class.

Instead, `StochasticProcess` now uses matrix multiplication for the `step` method (which, for two 1x1 arrays is the same as normal multiplication), so the functionality for `JointStochasticProcess` is entirely replicated by this change.

I think it's much cleaner just to have a single `StochasticProcess` base class where everything lives. I've added a `dim` parameter that is currently unused, but I will create an issue to validate `x0` arrays that are passed to the class's methods to ensure that the array matches the expected size of the process.