### PR TITLE
add "example" constructor for each model

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Economic Scenario Generator for Python.
 
 [![MIT License](https://img.shields.io/apm/l/atomic-design-ui.svg?)](https://github.com/tterb/atomic-design-ui/blob/master/LICENSEs)
+[![PyPI pyversions](https://img.shields.io/pypi/pyversions/pyesg.svg)](https://pypi.python.org/pypi/pyesg/)
 [![PyPI version](https://badge.fury.io/py/pyesg.svg)](https://badge.fury.io/py/pyesg)
 
 ## Objectives

--- a/pyesg/processes/academy_rate_process.py
+++ b/pyesg/processes/academy_rate_process.py
@@ -213,6 +213,27 @@ class AcademyRateProcess(StochasticProcess):
         # with the cholesky decomposition of the correlation matrix.
         return np.diag(volatility) @ cholesky
 
+    @classmethod
+    def example(cls):
+        return cls(
+            beta1=0.00509,
+            beta2=0.02685,
+            beta3=0.04001,
+            rho12=-0.19197,
+            rho13=0.0,
+            rho23=0.0,
+            sigma2=0.04148,
+            sigma3=0.11489,
+            tau1=0.035,
+            tau2=0.01,
+            tau3=0.0287,
+            theta=1.0,
+            phi=0.0002,
+            psi=0.25164,
+            long_rate_max=0.18,
+            long_rate_min=0.0115,
+        )
+
 
 if __name__ == "__main__":
     import doctest

--- a/pyesg/processes/black_scholes_process.py
+++ b/pyesg/processes/black_scholes_process.py
@@ -43,6 +43,10 @@ class BlackScholesProcess(StochasticProcess):
     def _diffusion(self, x0: np.ndarray) -> np.ndarray:
         return to_array(self.sigma)
 
+    @classmethod
+    def example(cls):
+        return cls(mu=0.05, sigma=0.2, dividend=0.01)
+
 
 if __name__ == "__main__":
     import doctest

--- a/pyesg/processes/cox_ingersoll_ross_process.py
+++ b/pyesg/processes/cox_ingersoll_ross_process.py
@@ -47,6 +47,10 @@ class CoxIngersollRossProcess(StochasticProcess):
     def _diffusion(self, x0: np.ndarray) -> np.ndarray:
         return self.sigma * x0 ** 0.5
 
+    @classmethod
+    def example(cls):
+        return cls(mu=0.05, sigma=0.02, theta=0.1)
+
 
 if __name__ == "__main__":
     import doctest

--- a/pyesg/processes/geometric_brownian_motion.py
+++ b/pyesg/processes/geometric_brownian_motion.py
@@ -48,6 +48,10 @@ class GeometricBrownianMotion(StochasticProcess):
     def _diffusion(self, x0: np.ndarray) -> np.ndarray:
         return self.sigma * x0
 
+    @classmethod
+    def example(cls):
+        return cls(mu=0.05, sigma=0.2)
+
 
 if __name__ == "__main__":
     import doctest

--- a/pyesg/processes/heston_process.py
+++ b/pyesg/processes/heston_process.py
@@ -73,6 +73,10 @@ class HestonProcess(StochasticProcess):
         volatility = np.diag([x0[0] * vol, self.sigma * vol])
         return volatility @ cholesky
 
+    @classmethod
+    def example(cls):
+        return cls(mu=0.05, kappa=0.8, sigma=0.001, theta=0.05, rho=-0.5)
+
 
 if __name__ == "__main__":
     import doctest

--- a/pyesg/processes/ornstein_uhlenbeck_process.py
+++ b/pyesg/processes/ornstein_uhlenbeck_process.py
@@ -47,6 +47,10 @@ class OrnsteinUhlenbeckProcess(StochasticProcess):
         # diffusion of an Ornstein-Uhlenbeck process does not depend on x0
         return to_array(self.sigma)
 
+    @classmethod
+    def example(cls):
+        return cls(mu=0.05, sigma=0.015, theta=0.15)
+
 
 if __name__ == "__main__":
     import doctest

--- a/pyesg/processes/wiener_process.py
+++ b/pyesg/processes/wiener_process.py
@@ -49,6 +49,10 @@ class WienerProcess(StochasticProcess):
         # diffusion of a Wiener process does not depend on x0
         return to_array(self.sigma)
 
+    @classmethod
+    def example(cls):
+        return cls(mu=0.05, sigma=0.2)
+
 
 class JointWienerProcess(StochasticProcess):
     """
@@ -103,6 +107,12 @@ class JointWienerProcess(StochasticProcess):
         volatility = np.diag(self.sigma)
         cholesky = np.linalg.cholesky(self.correlation)
         return volatility @ cholesky
+
+    @classmethod
+    def example(cls):
+        return cls(
+            mu=[0.05, 0.03], sigma=[0.20, 0.15], correlation=[[1.0, 0.5], [0.5, 1.0]]
+        )
 
 
 if __name__ == "__main__":

--- a/pyesg/stochastic_process.py
+++ b/pyesg/stochastic_process.py
@@ -22,6 +22,9 @@ class StochasticProcess(ABC):
         4. coefs : a convenience method that stores all model coefficients in a dict so
             they can be referenced easily as a group
 
+    In addition, each subclass should define a classmethod called `example`, which will
+    instantiate a model with reasonable parameters for users to be able to get started.
+
     Given these methods above, the base class provides methods for expected value of the
     process, standard deviation, and a transition density (if applicable). Also provides
     a method, "step", that iterates an initial vector of parameters one step forward.
@@ -60,6 +63,14 @@ class StochasticProcess(ABC):
     @abstractmethod
     def coefs(self) -> Dict[str, np.ndarray]:
         """Returns a dictionary of the process coefficients"""
+
+    @classmethod
+    @abstractmethod
+    def example(cls):  # creates an instance of the class with default parameters
+        """
+        Creates an instance of this model with sensible default parameters, primarily to
+        be able to visualize or understand the dynamics of the model quickly.
+        """
 
     def apply(self, x0: Array, dx: Array) -> np.ndarray:
         """Returns a new array of x-values, given a starting array and change vector"""

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,17 @@ setup(
     package_data={
         "pyesg": ["../README.md", "../LICENSE.md", "../MANIFEST.in", "datasets/*"]
     },
+    python_requires=">=3.6",  # f-strings
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "License :: OSI Approved :: MIT License",
+        "Topic :: Scientific/Engineering",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+    ],
     test_suite="tests",
     zip_safe=False,
 )


### PR DESCRIPTION
This makes is easy to create an "example" of each stochastic model with reasonable parameters, so that a user can quickly create a model and see how it behaves.