### PR TITLE
add rvs method to StochasticProcess

### DIFF
--- a/pyesg/stochastic_process.py
+++ b/pyesg/stochastic_process.py
@@ -101,21 +101,27 @@ class StochasticProcess(ABC):
     ) -> np.ndarray:
         """
         Returns the array of random variates used to generate a batch of scenarios with
-        shape (n_scenarios, n_steps, self.dim)
-        """
-        if self.dim == 1:
-            rvs = np.zeros(shape=(n_scenarios, n_steps))
-        else:
-            rvs = np.zeros(shape=(n_scenarios, n_steps, self.dim))
+        shape (n_scenarios, n_steps, self.dim). If dim == 1, then the third dimension
+        will be squeezed, so the returned array will have shape (n_scenarios, n_steps).
 
+        Parameters
+        ----------
+        n_scenarios : int, the number of scenarios to generate, e.g. 1000
+        n_steps : int, the number of steps in the scenario, e.g. 52
+        random_state : Union[int, np.random.RandomState, None], either an integer seed
+            or a numpy RandomState object directly, if reproducibility is desired
+
+        Returns
+        -------
+        rvs : np.ndarray, an array of the random variates used to generate scenarios
+        """
+        rvs = np.zeros(shape=(n_scenarios, n_steps, self.dim))
         for i in range(n_steps):
             random_state = check_random_state(random_state)
-            if self.dim == 1:
-                rvs[:, i] = self.dW.rvs(size=n_scenarios, random_state=random_state)
-            else:
-                size = (n_scenarios, self.dim)
-                rvs[:, i, :] = self.dW.rvs(size=size, random_state=random_state)
-        return rvs
+            rvs[:, i, :] = self.dW.rvs(
+                size=(n_scenarios, self.dim), random_state=random_state
+            )
+        return rvs.squeeze()
 
     def step(
         self, x0: Array, dt: float, random_state: RandomState = None

--- a/pyesg/stochastic_process.py
+++ b/pyesg/stochastic_process.py
@@ -96,6 +96,27 @@ class StochasticProcess(ABC):
         """
         return self.diffusion(x0=x0) * dt ** 0.5
 
+    def rvs(
+        self, n_scenarios: int, n_steps: int, random_state: RandomState = None
+    ) -> np.ndarray:
+        """
+        Returns the array of random variates used to generate a batch of scenarios with
+        shape (n_scenarios, n_steps, self.dim)
+        """
+        if self.dim == 1:
+            rvs = np.zeros(shape=(n_scenarios, n_steps))
+        else:
+            rvs = np.zeros(shape=(n_scenarios, n_steps, self.dim))
+
+        for i in range(n_steps):
+            random_state = check_random_state(random_state)
+            if self.dim == 1:
+                rvs[:, i] = self.dW.rvs(size=n_scenarios, random_state=random_state)
+            else:
+                size = (n_scenarios, self.dim)
+                rvs[:, i, :] = self.dW.rvs(size=size, random_state=random_state)
+        return rvs
+
     def step(
         self, x0: Array, dt: float, random_state: RandomState = None
     ) -> np.ndarray:

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -180,19 +180,15 @@ class BaseProcessMixin:
         # for 100 scenarios and 30 timesteps will be generated 30 at a time, populating
         # each time step of each scenario in a row. To test this, we generate an array
         # of random variables, then reshape it to check that it matches what we expect.
-        n_scenarios, n_steps, random_state = 1000, 120, 123
-        if self.model.dim == 1:
-            expected = self.model.dW.rvs(
-                size=n_scenarios * n_steps, random_state=random_state
-            )
-            expected = expected.reshape(n_scenarios, n_steps, order="F")
+        scen, step, state, dim = 1000, 120, 123, self.model.dim
+        if dim == 1:
+            expected = self.model.dW.rvs(size=scen * step, random_state=state)
+            expected = expected.reshape(scen, step, order="F")
         else:
-            expected = self.model.dW.rvs(
-                size=n_scenarios * n_steps * self.model.dim, random_state=random_state
-            )
-            expected = expected.reshape(n_scenarios * n_steps, self.model.dim)
-            expected = expected.reshape(n_scenarios, n_steps, self.model.dim, order="F")
-        actual = self.model.rvs(n_scenarios, n_steps, random_state)
+            expected = self.model.dW.rvs(size=scen * step * dim, random_state=state)
+            expected = expected.reshape(scen * step, dim)
+            expected = expected.reshape(scen, step, dim, order="F")
+        actual = self.model.rvs(scen, step, state)
         self.assertIsNone(np.testing.assert_array_equal(actual, expected))
 
 

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -173,6 +173,28 @@ class BaseProcessMixin:
             30,  # n_steps
         )
 
+    def test_rvs(self):
+        """Ensure the array of random variates matches what we expect"""
+        # scenarios are generated sequentially by time step, so the number of scenarios
+        # impacts where the array of random variates goes. For example, an array of rvs
+        # for 100 scenarios and 30 timesteps will be generated 30 at a time, populating
+        # each time step of each scenario in a row. To test this, we generate an array
+        # of random variables, then reshape it to check that it matches what we expect.
+        n_scenarios, n_steps, random_state = 1000, 120, 123
+        if self.model.dim == 1:
+            expected = self.model.dW.rvs(
+                size=n_scenarios * n_steps, random_state=random_state
+            )
+            expected = expected.reshape(n_scenarios, n_steps, order="F")
+        else:
+            expected = self.model.dW.rvs(
+                size=n_scenarios * n_steps * self.model.dim, random_state=random_state
+            )
+            expected = expected.reshape(n_scenarios * n_steps, self.model.dim)
+            expected = expected.reshape(n_scenarios, n_steps, self.model.dim, order="F")
+        actual = self.model.rvs(n_scenarios, n_steps, random_state)
+        self.assertIsNone(np.testing.assert_array_equal(actual, expected))
+
 
 class TestCoxIngersollRossProcess(BaseProcessMixin, unittest.TestCase):
     """Test CoxIngersollRossProcess"""


### PR DESCRIPTION
This method returns the random variates that were used to generate a set
of scenarios for a stochastic process. Useful for debugging outputs.