### PR TITLE
Upgrade pylint to 2.6.0

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,6 +3,9 @@ disable=
     fixme,
     invalid-name
 
+[SIMILARITIES]
+min-similarity-lines=20
+
 [TYPECHECK]
 
 # List of members which are set dynamically and missed by pylint inference

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,7 +1,5 @@
 [MESSAGES CONTROL]
 disable=
-    bad-continuation,
-    duplicate-code,
     fixme,
     invalid-name
 

--- a/pyesg/stochastic_process.py
+++ b/pyesg/stochastic_process.py
@@ -155,7 +155,8 @@ class StochasticProcess(ABC):
                 dx = np.einsum("ab,acb->ac", rvs, self.standard_deviation(x0=x0, dt=dt))
         return self.apply(self.expectation(x0=x0, dt=dt), dx)
 
-    def scenarios(  # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments
+    def scenarios(
         self,
         x0: Array,
         dt: float,
@@ -202,11 +203,11 @@ class StochasticProcess(ABC):
         try:
             # can we broadcast the x0 array into the number of scenarios we want?
             samples[:, 0] = x0
-        except ValueError:
+        except ValueError as err:
             raise ValueError(
                 f"Could not broadcast the input array, with shape {x0.shape}, into "
                 f"the scenario output array, with shape {samples.shape}"
-            )
+            ) from err
 
         # then we iterate through scenarios along the timesteps dimension
         for i in range(n_steps):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
             "coverage==5.2.1",
             "hypothesis==5.24.4",
             "pre-commit==2.6.0",
-            "pylint==2.5.3",
+            "pylint==2.6.0",
             "mypy==0.782",
         ]
     },


### PR DESCRIPTION
This removes some of the false positives that were previously excluded in `.pylintrc`, like `bad-continuation`. Also removed `duplicate-code` because it wasn't catching any errors.