### PR TITLE
move __version__ to pyesg/version.py

### DIFF
--- a/pyesg/__init__.py
+++ b/pyesg/__init__.py
@@ -14,6 +14,7 @@ from pyesg.processes.ho_lee_process import HoLeeProcess
 from pyesg.processes.ornstein_uhlenbeck_process import OrnsteinUhlenbeckProcess
 from pyesg.processes.wiener_process import JointWienerProcess, WienerProcess
 
+from pyesg.version import __version__
 
 __all__ = (
     "AcademyRateModel",
@@ -30,6 +31,3 @@ __all__ = (
     "JointWienerProcess",
     "WienerProcess",
 )
-
-
-__version__ = "0.1.4"

--- a/pyesg/version.py
+++ b/pyesg/version.py
@@ -1,0 +1,3 @@
+"""Package version"""
+
+__version__ = "0.1.4"

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,17 @@
 from setuptools import setup, find_packages
 
 
+with open("pyesg/version.py") as f:
+    __version__ = None
+    exec(f.read(), globals())  # pylint: disable=exec-used
+
+
 with open("README.md") as f:
     README = f.read()
 
 setup(
     name="pyesg",
-    version="0.1.4",
+    version=__version__,
     description="Economic Scenario Generator for Python",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR moves all references to `__version__` to a single file, `pyesg/version.py`.