### PR TITLE
bump version to 0.1.5 for new release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/images/pyesg.png" width="450" />
+  <img src="https://github.com/jason-ash/pyesg/blob/master/docs/images/pyesg.png" width="450" />
 </p>
 <p align="center">
   <em>Simulate stocks, interest rates, and other stochastic processes.<br><strong>pyesg</strong> is a lightning fast economic scenario generator for Python.</em>
@@ -268,7 +268,7 @@ nelson_siegel.predict(np.arange(1, 31, 1))
 ```
 
 <p align="center">
-  <img src="docs/images/NelsonSiegel.png" width="600">
+  <img src="https://github.com/jason-ash/pyesg/blob/master/docs/images/NelsonSiegel.png" width="600">
 </p>
 
 ## License

--- a/README.md
+++ b/README.md
@@ -272,4 +272,4 @@ nelson_siegel.predict(np.arange(1, 31, 1))
 </p>
 
 ## License
-Open Source and licensed under MIT, Copyright &copy; 2019-2020 Jason Ash
+Open Source and licensed under MIT, Copyright &copy; 2019-2021 Jason Ash

--- a/pyesg/version.py
+++ b/pyesg/version.py
@@ -1,3 +1,3 @@
 """Package version"""
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"


### PR DESCRIPTION
This release is a minor upgrade from the prior `0.1.4` version. I introduced `mypy --strict`, and slightly improved the type hints throughout the project, which may slightly change the intellitype in some editors, but shouldn't affect package functionality at all.